### PR TITLE
Bump mediawiki_api version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,6 @@ rvm:
  - 2.1.1
  - 2.0.0
  - 1.9.3
+before_install:
+ - gem install bundler # https://github.com/travis-ci/travis-ci/issues/5239
 script: rspec spec

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ wikidata_client.search_entities "test", "en", "item" #searches for items contain
 
 ## Release notes
 
+### 0.2.1 (2016-05-26)
+- Compatible with [mediawiki_api 6.0](https://rubygems.org/gems/mediawiki_api/versions/0.6.0)
+
 ### 0.2.0 (2015-10-09)
 - Compatible with [mediawiki_api 5.0](https://rubygems.org/gems/mediawiki_api/versions/0.5.0)
 

--- a/lib/mediawiki_api/wikidata/version.rb
+++ b/lib/mediawiki_api/wikidata/version.rb
@@ -1,5 +1,5 @@
 module MediawikiApi
   module Wikidata
-    VERSION = "0.2.0"
+    VERSION = "0.2.1"
   end
 end

--- a/mediawiki_api-wikidata.gemspec
+++ b/mediawiki_api-wikidata.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "mediawiki_api", "~> 0.5.0"
+  spec.add_runtime_dependency "mediawiki_api", "~> 0.6.0"
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake", "~> 0"


### PR DESCRIPTION
Update for AuthManager API changes, see [T135884](https://phabricator.wikimedia.org/T135884) for details.